### PR TITLE
build: 适配 wsl 开发

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 registry=https://registry.npmmirror.com/
-shamefully-hoist=false
+symlink=false
+node-linker=hoisted


### PR DESCRIPTION
wsl 使用跨文件系统工作时无法使用软连接，所以改用硬链接